### PR TITLE
US66937 - Update LOReS library dependencies

### DIFF
--- a/D2L.Services.Core.WebApi.IntegrationTests/app.config
+++ b/D2L.Services.Core.WebApi.IntegrationTests/app.config
@@ -10,6 +10,14 @@
 				<assemblyIdentity name="Newtonsoft.Json" publicKeyToken="30ad4fe6b2a6aeed" culture="neutral" />
 				<bindingRedirect oldVersion="0.0.0.0-7.0.0.0" newVersion="7.0.0.0" />
 			</dependentAssembly>
+			<dependentAssembly>
+				<assemblyIdentity name="System.Web.Http" publicKeyToken="31bf3856ad364e35" culture="neutral" />
+				<bindingRedirect oldVersion="0.0.0.0-4.0.0.0" newVersion="4.0.0.0" />
+			</dependentAssembly>
+			<dependentAssembly>
+				<assemblyIdentity name="System.Net.Http.Formatting" publicKeyToken="31bf3856ad364e35" culture="neutral" />
+				<bindingRedirect oldVersion="0.0.0.0-4.0.0.0" newVersion="4.0.0.0" />
+			</dependentAssembly>
 		</assemblyBinding>
 	</runtime>
 <startup><supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.5.1" /></startup></configuration>

--- a/D2L.Services.Core.WebApi/Auth/D2LPrincipalWrapper.cs
+++ b/D2L.Services.Core.WebApi/Auth/D2LPrincipalWrapper.cs
@@ -24,6 +24,10 @@ namespace D2L.Services.Core.WebApi.Auth {
 			get { return m_principal.Value.AccessToken; }
 		}
 
+		long ID2LPrincipal.ActualUserId {
+			get { return m_principal.Value.ActualUserId; }
+		}
+
 		IEnumerable<Scope> ID2LPrincipal.Scopes {
 			get { return m_principal.Value.Scopes; }
 		}
@@ -36,7 +40,7 @@ namespace D2L.Services.Core.WebApi.Auth {
 			get { return m_principal.Value.Type; }
 		}
 
-		string ID2LPrincipal.UserId {
+		long ID2LPrincipal.UserId {
 			get { return m_principal.Value.UserId; }
 		}
 

--- a/D2L.Services.Core.WebApi/D2L.Services.Core.WebApi.csproj
+++ b/D2L.Services.Core.WebApi/D2L.Services.Core.WebApi.csproj
@@ -33,13 +33,13 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="D2L.Security.OAuth2, Version=4.4.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\packages\D2L.Security.OAuth2.4.4.0.0\lib\net451\D2L.Security.OAuth2.dll</HintPath>
+    <Reference Include="D2L.Security.OAuth2, Version=5.0.3.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\D2L.Security.OAuth2.5.0.3.0\lib\net451\D2L.Security.OAuth2.dll</HintPath>
+      <Private>True</Private>
     </Reference>
-    <Reference Include="D2L.Security.OAuth2.WebApi, Version=3.2.3.0, Culture=neutral, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\packages\D2L.Security.OAuth2.WebApi.3.2.3.0\lib\net451\D2L.Security.OAuth2.WebApi.dll</HintPath>
+    <Reference Include="D2L.Security.OAuth2.WebApi, Version=5.0.3.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\D2L.Security.OAuth2.WebApi.5.0.3.0\lib\net451\D2L.Security.OAuth2.WebApi.dll</HintPath>
+      <Private>True</Private>
     </Reference>
     <Reference Include="D2L.Services.Core.Activation, Version=3.0.0.0, Culture=neutral, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
@@ -48,6 +48,10 @@
     <Reference Include="D2L.Services.Core.Configuration, Version=3.0.0.0, Culture=neutral, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
       <HintPath>..\packages\D2L.Services.Core.Configuration.3.0.0.0\lib\net451\D2L.Services.Core.Configuration.dll</HintPath>
+    </Reference>
+    <Reference Include="D2L.Services.Core.Exceptions, Version=1.0.0.27289, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\D2L.Services.Core.Exceptions.1.0.0.27289\lib\net451\D2L.Services.Core.Exceptions.dll</HintPath>
+      <Private>True</Private>
     </Reference>
     <Reference Include="D2L.Services.Core.Extensions, Version=1.1.1.0, Culture=neutral, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>

--- a/D2L.Services.Core.WebApi/Properties/AssemblyInfo.cs
+++ b/D2L.Services.Core.WebApi/Properties/AssemblyInfo.cs
@@ -31,5 +31,5 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyFileVersion("1.0.*")]
+[assembly: AssemblyVersion("0.0.14.0")]
+[assembly: AssemblyFileVersion("0.0.14.0")]

--- a/D2L.Services.Core.WebApi/Properties/AssemblyInfo.cs
+++ b/D2L.Services.Core.WebApi/Properties/AssemblyInfo.cs
@@ -31,5 +31,5 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("0.0.13.0")]
-[assembly: AssemblyFileVersion("0.0.13.0")]
+[assembly: AssemblyVersion("1.0.*")]
+[assembly: AssemblyFileVersion("1.0.*")]

--- a/D2L.Services.Core.WebApi/packages.config
+++ b/D2L.Services.Core.WebApi/packages.config
@@ -1,9 +1,10 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="D2L.Security.OAuth2" version="4.4.0.0" targetFramework="net451" />
-  <package id="D2L.Security.OAuth2.WebApi" version="3.2.3.0" targetFramework="net451" />
+  <package id="D2L.Security.OAuth2" version="5.0.3.0" targetFramework="net451" />
+  <package id="D2L.Security.OAuth2.WebApi" version="5.0.3.0" targetFramework="net451" />
   <package id="D2L.Services.Core.Activation" version="3.0.0.0" targetFramework="net451" />
   <package id="D2L.Services.Core.Configuration" version="3.0.0.0" targetFramework="net451" />
+  <package id="D2L.Services.Core.Exceptions" version="1.0.0.27289" targetFramework="net451" />
   <package id="D2L.Services.Core.Extensions" version="1.1.1.0" targetFramework="net451" />
   <package id="Microsoft.AspNet.Cors" version="5.2.3" targetFramework="net451" />
   <package id="Microsoft.AspNet.WebApi.Client" version="5.2.3" targetFramework="net451" />


### PR DESCRIPTION
- Updated this library to use the newest D2L.Security.OAuth2 and D2L.Security.OAuth2.WebApi libraries, to allow this library to be used in Services that also use these newest library versions
- The single integration test passes

- Have I missed anything?  