### PR TITLE
Make D2L.Services.Core.WebApi more test-friendly

### DIFF
--- a/D2L.Services.Core.WebApi.IntegrationTests/D2L.Services.Core.WebApi.IntegrationTests.csproj
+++ b/D2L.Services.Core.WebApi.IntegrationTests/D2L.Services.Core.WebApi.IntegrationTests.csproj
@@ -105,6 +105,7 @@
   <ItemGroup>
     <Compile Include="ServiceTests.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
+    <Compile Include="TestDependencyResolverTests.cs" />
   </ItemGroup>
   <ItemGroup>
     <None Include="app.config" />

--- a/D2L.Services.Core.WebApi.IntegrationTests/TestDependencyResolverTests.cs
+++ b/D2L.Services.Core.WebApi.IntegrationTests/TestDependencyResolverTests.cs
@@ -1,0 +1,74 @@
+﻿using System;
+using System.Web.Http.Dependencies;
+using D2L.Services.Core.Activation;
+using D2L.Services.Core.WebApi.TestUtils;
+using NUnit.Framework;
+
+namespace D2L.Services.Core.WebApi {
+	
+	[TestFixture]
+	public sealed class TestDependencyResolverTests {
+		
+		private interface TestInterface {}
+		private sealed class OriginalType : TestInterface {}
+		private sealed class OverrideType : TestInterface {}
+		
+		private IDependencyResolver m_resolver;
+		private TestDependencyRegistry m_testDependencyRegistry;
+		
+		[TestFixtureSetUp]
+		public void TestFixtureSetUp() {
+			m_testDependencyRegistry = new TestDependencyRegistry();
+			m_resolver = new TestDependencyResolver(
+				m_testDependencyRegistry,
+				DependencyResolverFactory.CreateFrom<TestDependencyLoader>()
+			);
+		}
+		
+		[TestFixtureTearDown]
+		public void TestFixtureTearDown() {
+			m_resolver.SafeDispose();
+		}
+		
+		[SetUp]
+		public void SetUp() {
+			m_testDependencyRegistry.ClearAllOverrides();
+		}
+		
+		[Test]
+		public void SimpleTest() {
+			Assert.IsTrue( m_resolver.Get<TestInterface>() is OriginalType );
+			m_testDependencyRegistry.OverrideDependency<TestInterface>( new OverrideType() );
+			Assert.IsTrue( m_resolver.Get<TestInterface>() is OverrideType );
+			m_testDependencyRegistry.ClearOverride<TestInterface>();
+			Assert.IsTrue( m_resolver.Get<TestInterface>() is OriginalType );
+		}
+		
+		[Test]
+		public void DependencyScopeTest() {
+			using( IDependencyScope scope = m_resolver.BeginScope() ) {
+				Assert.IsTrue( m_resolver.Get<TestInterface>() is OriginalType );
+				Assert.IsTrue( scope.Get<TestInterface>() is OriginalType );
+				
+				m_testDependencyRegistry.OverrideDependency<TestInterface>( new OverrideType() );
+				
+				Assert.IsTrue( m_resolver.Get<TestInterface>() is OverrideType );
+				Assert.IsTrue( scope.Get<TestInterface>() is OverrideType );
+				
+				m_testDependencyRegistry.ClearOverride<TestInterface>();
+				
+				Assert.IsTrue( m_resolver.Get<TestInterface>() is OriginalType );
+				Assert.IsTrue( scope.Get<TestInterface>() is OriginalType );
+			}
+		}
+		
+		
+		private sealed class TestDependencyLoader : IDependencyLoader {
+			void IDependencyLoader.Load( IDependencyRegistry registry ) {
+				registry.Register<TestInterface,OriginalType>( ObjectScope.Singleton );
+			}
+		}
+		
+	}
+	
+}

--- a/D2L.Services.Core.WebApi/D2L.Services.Core.WebApi.csproj
+++ b/D2L.Services.Core.WebApi/D2L.Services.Core.WebApi.csproj
@@ -119,12 +119,19 @@
     <Compile Include="Extensions\System.Web.Http.HttpConfiguration.Extensions.cs" />
     <Compile Include="IService.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
+    <Compile Include="Properties\FriendAssemblies.cs" />
     <Compile Include="Service.cs" />
     <Compile Include="ServiceDescriptor.cs" />
+    <Compile Include="TestUtils\TestDependencyRegistry.cs" />
+    <Compile Include="TestUtils\TestDependencyResolver.cs" />
+    <Compile Include="TestUtils\TestDependencyScope.cs" />
   </ItemGroup>
   <ItemGroup>
     <None Include="app.config" />
     <None Include="packages.config" />
+  </ItemGroup>
+  <ItemGroup>
+    <Folder Include="TestUtils" />
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <Import Project="$(SolutionDir)\.nuget\NuGet.targets" Condition="Exists('$(SolutionDir)\.nuget\NuGet.targets')" />

--- a/D2L.Services.Core.WebApi/Properties/FriendAssemblies.cs
+++ b/D2L.Services.Core.WebApi/Properties/FriendAssemblies.cs
@@ -1,0 +1,3 @@
+﻿using System.Runtime.CompilerServices;
+
+[assembly: InternalsVisibleTo( "D2L.Services.Core.WebApi.IntegrationTests" )]

--- a/D2L.Services.Core.WebApi/Service.cs
+++ b/D2L.Services.Core.WebApi/Service.cs
@@ -5,6 +5,7 @@ using System.Web.Http.Dependencies;
 using D2L.Services.Core.Activation;
 using D2L.Services.Core.Configuration;
 using D2L.Services.Core.WebApi.Auth;
+using D2L.Services.Core.WebApi.TestUtils;
 using Microsoft.Owin.Hosting;
 using Owin;
 using SimpleLogInterface;
@@ -26,7 +27,8 @@ namespace D2L.Services.Core.WebApi {
 			IConfigViewer configViewer,
 			ILogProvider logProvider,
 			Action<HttpConfiguration> startup,
-			Type dependencyLoaderType
+			Type dependencyLoaderType,
+			TestDependencyRegistry testDependencyRegistry = null
 		) {
 			m_url = url;
 			m_descriptor = descriptor;
@@ -41,6 +43,13 @@ namespace D2L.Services.Core.WebApi {
 					dependencyLoaderType
 				)
 			);
+			
+			if( testDependencyRegistry != null ) {
+				m_dependencyResolver = new TestDependencyResolver(
+					testDependencyRegistry,
+					m_dependencyResolver
+				);
+			}
 		}
 
 		ServiceDescriptor IService.Descriptor {

--- a/D2L.Services.Core.WebApi/Service.cs
+++ b/D2L.Services.Core.WebApi/Service.cs
@@ -27,8 +27,7 @@ namespace D2L.Services.Core.WebApi {
 			IConfigViewer configViewer,
 			ILogProvider logProvider,
 			Action<HttpConfiguration> startup,
-			Type dependencyLoaderType,
-			TestDependencyRegistry testDependencyRegistry = null
+			Type dependencyLoaderType
 		) {
 			m_url = url;
 			m_descriptor = descriptor;
@@ -43,7 +42,24 @@ namespace D2L.Services.Core.WebApi {
 					dependencyLoaderType
 				)
 			);
-			
+		}
+		
+		public Service(
+			string url,
+			ServiceDescriptor descriptor,
+			IConfigViewer configViewer,
+			ILogProvider logProvider,
+			Action<HttpConfiguration> startup,
+			Type dependencyLoaderType,
+			TestDependencyRegistry testDependencyRegistry
+		) : this(
+			url,
+			descriptor,
+			configViewer,
+			logProvider,
+			startup,
+			dependencyLoaderType
+		) {
 			if( testDependencyRegistry != null ) {
 				m_dependencyResolver = new TestDependencyResolver(
 					testDependencyRegistry,

--- a/D2L.Services.Core.WebApi/TestUtils/TestDependencyRegistry.cs
+++ b/D2L.Services.Core.WebApi/TestUtils/TestDependencyRegistry.cs
@@ -1,0 +1,38 @@
+﻿
+using System;
+using System.Collections.Generic;
+
+namespace D2L.Services.Core.WebApi.TestUtils {
+	
+	public sealed class TestDependencyRegistry {
+		
+		private readonly IDictionary<Type,object> m_overrides;
+		
+		public TestDependencyRegistry() {
+			m_overrides = new Dictionary<Type,object>();
+		}
+		
+		public void OverrideDependency<DependencyType>(
+			DependencyType dependencyOverride
+		) {
+			m_overrides[typeof( DependencyType )] = (object)dependencyOverride;
+		}
+		
+		public void ClearOverride<DependencyType>() {
+			m_overrides.Remove( typeof( DependencyType ) );
+		}
+		
+		public void ClearAllOverrides() {
+			m_overrides.Clear();
+		}
+		
+		internal bool TryGet(
+			Type dependencyType,
+			out object dependencyOverride
+		) {
+			return m_overrides.TryGetValue( dependencyType, out dependencyOverride );
+		}
+		
+	}
+	
+}

--- a/D2L.Services.Core.WebApi/TestUtils/TestDependencyResolver.cs
+++ b/D2L.Services.Core.WebApi/TestUtils/TestDependencyResolver.cs
@@ -1,0 +1,26 @@
+﻿using System;
+using System.Web.Http.Dependencies;
+
+namespace D2L.Services.Core.WebApi.TestUtils {
+	
+	internal sealed class TestDependencyResolver : TestDependencyScope, IDependencyResolver {
+		
+		private readonly IDependencyResolver m_innerResolver;
+		
+		internal TestDependencyResolver(
+			TestDependencyRegistry dependencyOverrides,
+			IDependencyResolver innerResolver
+		) : base( dependencyOverrides, innerResolver ) {
+			m_innerResolver = innerResolver;
+		}
+		
+		IDependencyScope IDependencyResolver.BeginScope() {
+			return new TestDependencyScope(
+				m_overrides,
+				m_innerResolver.BeginScope()
+			);
+		}
+		
+	}
+	
+}

--- a/D2L.Services.Core.WebApi/TestUtils/TestDependencyScope.cs
+++ b/D2L.Services.Core.WebApi/TestUtils/TestDependencyScope.cs
@@ -1,0 +1,39 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Web.Http.Dependencies;
+
+namespace D2L.Services.Core.WebApi.TestUtils {
+	
+	internal class TestDependencyScope : IDependencyScope {
+		
+		protected readonly TestDependencyRegistry m_overrides;
+		private readonly IDependencyScope m_innerScope;
+		
+		internal TestDependencyScope(
+			TestDependencyRegistry dependencyOverrides,
+			IDependencyScope innerScope
+		) {
+			m_overrides = dependencyOverrides;
+			m_innerScope = innerScope;
+		}
+		
+		object IDependencyScope.GetService( Type serviceType ) {
+			object service = null;
+			if( m_overrides.TryGet( serviceType, out service ) ) {
+				return service;
+			}
+			
+			return m_innerScope.GetService( serviceType );
+		}
+		
+		IEnumerable<object> IDependencyScope.GetServices( Type serviceType ) {
+			return m_innerScope.GetServices( serviceType );
+		}
+		
+		void IDisposable.Dispose() {
+			m_innerScope.Dispose();
+		}
+		
+	}
+	
+}


### PR DESCRIPTION
Make contract testing easier by allowing dependency overrides to be passed into the Service through a `TestDependencyRegistry`.

This is most useful for contract tests in which calls to the LMS or other services must be mocked or where `IServiceConfig` needs to be mocked.

Previously, this required an ugly solution with a dependency loader having a static override list.
